### PR TITLE
Adding support to point to an ipinfo cache

### DIFF
--- a/pkg/resolver/location_resolver.go
+++ b/pkg/resolver/location_resolver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -63,9 +64,16 @@ func (i *IPInfo) Resolve() {
 
 func GetPublicIPInfo(ctx context.Context, ip string, token string) (IPInfo, error) {
 	logger := logging.Logger("location_resolver")
-	url := "https://ipinfo.io/json"
-	if ip != "" {
-		url = "https://ipinfo.io/" + ip + "/json"
+	url, exists := os.LookupEnv("IPINFO_URL")
+	if !exists {
+		url = "https://ipinfo.io/"
+		if ip != "" {
+			url = url + ip + "/json"
+		}
+	} else {
+		if ip != "" {
+			url = url + ip
+		}
 	}
 
 	if token != "" {

--- a/pkg/resolver/location_resolver.go
+++ b/pkg/resolver/location_resolver.go
@@ -67,13 +67,9 @@ func GetPublicIPInfo(ctx context.Context, ip string, token string) (IPInfo, erro
 	url, exists := os.LookupEnv("IPINFO_URL")
 	if !exists {
 		url = "https://ipinfo.io/"
-		if ip != "" {
-			url = url + ip + "/json"
-		}
-	} else {
-		if ip != "" {
-			url = url + ip
-		}
+	}
+	if ip != "" {
+		url = url + ip + "/json"
 	}
 
 	if token != "" {


### PR DESCRIPTION
Example postman to show things are hooked up correctly

https://xbj3ebrf2c.execute-api.us-east-2.amazonaws.com/ipinfo/8.8.8.8

{'ip': '8.8.8.8', 'hostname': 'dns.google', 'anycast': True, 'city': 'Mountain View', 'region': 'California', 'country': 'US', 'loc': '37.4056,-122.0775', 'org': 'AS15169 Google LLC', 'postal': '94043', 'timezone': 'America/Los_Angeles', 'readme': 'https://ipinfo.io/missingauth'}